### PR TITLE
Fix crash when parsing some new InsydeH2O bios from Acer, like A615-51G.

### DIFF
--- a/UEFI.cpp
+++ b/UEFI.cpp
@@ -188,6 +188,13 @@ void getUEFIFormSets(vector<UEFI_IFR_FORM_SET_PACK> &formSets, const string &buf
             tempFormSet.header.type = static_cast<unsigned char>(buffer[i + 3]);
             tempFormSet.titleString = static_cast<uint16_t>(static_cast<unsigned char>(buffer[i + 22]) + (static_cast<unsigned char>(buffer[i + 23]) << 8));
             tempFormSet.usingStringPackage = chosenCandidate;
+
+            // Fix when the selected string package is not enough to decode the string.
+            if (tempFormSet.titleString + stringPackages[chosenCandidate].structureOffset < strings.size())
+                tempFormSet.usingStringPackage = chosenCandidate;
+            else
+                tempFormSet.usingStringPackage = stringCandidates[0];
+
             tempFormSet.title = strings[tempFormSet.titleString + stringPackages[tempFormSet.usingStringPackage].structureOffset];
 
             // Add temp form set to list


### PR DESCRIPTION
Try to fix #2 , The new bios will try to use both language package in one form set, so we would try to check before use.