### PR TITLE
Fixed overflow when parsing some files

### DIFF
--- a/UEFI.cpp
+++ b/UEFI.cpp
@@ -188,6 +188,12 @@ void getUEFIFormSets(vector<UEFI_IFR_FORM_SET_PACK> &formSets, const string &buf
             tempFormSet.header.type = static_cast<unsigned char>(buffer[i + 3]);
             tempFormSet.titleString = static_cast<uint16_t>(static_cast<unsigned char>(buffer[i + 22]) + (static_cast<unsigned char>(buffer[i + 23]) << 8));
             tempFormSet.usingStringPackage = chosenCandidate;
+            
+            // Avoid overflow
+            if(tempFormSet.titleString > strings.size() || tempFormSet.usingStringPackage > stringPackages.size()) {
+                continue;
+            }
+            
             tempFormSet.title = strings[tempFormSet.titleString + stringPackages[tempFormSet.usingStringPackage].structureOffset];
 
             // Add temp form set to list


### PR DESCRIPTION
On some BIOSes, especially the BRIX (https://www.gigabyte.com/Mini-PcBarebone/GB-BKi5HA-7200-rev-10#ov), there was an overflow in case `tempFormSet.titleString > strings.size()`. This patch fixes the issue.